### PR TITLE
Fix bug writing 64bit integers with JS Number's

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class ByteStream {
         break
       case 'number':
         this.buffer.writeUInt32LE(value & 0xffffffff, this.writeOffset)
-        this.buffer.writeUInt32LE(value >>> 32, this.writeOffset + 4)
+        this.buffer.writeUInt32LE(Math.floor(value / 4294967296), this.writeOffset + 4)
         break
       default:
         throw new Error('Invalid value type')
@@ -93,7 +93,7 @@ class ByteStream {
         this.buffer.writeBigUInt64BE(value, this.writeOffset)
         break
       case 'number':
-        this.buffer.writeUInt32BE(value >>> 32, this.writeOffset)
+        this.buffer.writeUInt32BE(Math.floor(value / 4294967296), this.writeOffset)
         this.buffer.writeUInt32BE(value & 0xffffffff, this.writeOffset + 4)
         break
       default:
@@ -131,7 +131,7 @@ class ByteStream {
         break
       case 'number':
         this.buffer.writeInt32LE(value & 0xffffffff, this.writeOffset)
-        this.buffer.writeInt32LE(value >>> 32, this.writeOffset + 4)
+        this.buffer.writeInt32LE(Math.floor(value / 4294967296), this.writeOffset + 4)
         break
       default:
         throw new Error('Invalid value type')
@@ -159,7 +159,7 @@ class ByteStream {
         this.buffer.writeBigInt64BE(value, this.writeOffset)
         break
       case 'number':
-        this.buffer.writeInt32BE(value >>> 32, this.writeOffset)
+        this.buffer.writeInt32BE(Math.floor(value / 4294967296), this.writeOffset)
         this.buffer.writeInt32BE(value & 0xffffffff, this.writeOffset + 4)
         break
       default:

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,11 +11,11 @@ describe('basic tests', () => {
   it('Numbers with i64', () => {
     const stream = new ByteStream()
     stream.writeInt64LE(1)
-    assert(stream.getBuffer().equals(Buffer.from([1, 0, 0, 0, 0, 0, 0, 0])))  
+    assert(stream.getBuffer().equals(Buffer.from([1, 0, 0, 0, 0, 0, 0, 0])))
   })
   it('Negative Numbers with i64', () => {
     const stream = new ByteStream()
     stream.writeInt64LE(-1)
-    assert(stream.getBuffer().equals(Buffer.from([255, 255, 255, 255, 255, 255, 255, 255])))  
+    assert(stream.getBuffer().equals(Buffer.from([255, 255, 255, 255, 255, 255, 255, 255])))
   })
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -8,4 +8,14 @@ describe('basic tests', () => {
     stream.writeStringNT('hello world!')
     assert(stream.getBuffer().equals(Buffer.from('hello world!\0')))
   })
+  it('Numbers with i64', () => {
+    const stream = new ByteStream()
+    stream.writeInt64LE(1)
+    assert(stream.getBuffer().equals(Buffer.from([1, 0, 0, 0, 0, 0, 0, 0])))  
+  })
+  it('Negative Numbers with i64', () => {
+    const stream = new ByteStream()
+    stream.writeInt64LE(-1)
+    assert(stream.getBuffer().equals(Buffer.from([255, 255, 255, 255, 255, 255, 255, 255])))  
+  })
 })


### PR DESCRIPTION
Bit shifting in JS apparently only works if the Number uses less than 32 bits, so we'll switch to division. BigInts should be unaffected. 